### PR TITLE
Add FreeBSD submodule using gmake

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,6 +8,7 @@ my $class = $^O =~ /MSWin/          ? 'My::Build::Windows'
            : $^O =~ /darwin/        ? 'My::Build::MacOSX'
            : $^O =~ /GNU\/kFreeBSD/ ? 'My::Build::Linux' # Linux build process works for this particular BSD
            : $^O =~ /BSD/           ? 'My::Build::BSD'   # all other BSDs need slight modification
+           : $^O eq 'freebsd'       ? 'My::Build::FreeBSD'
            :                          'My::Build::Linux' # default to Linux
            ;
 

--- a/inc/My/Build/FreeBSD.pm
+++ b/inc/My/Build/FreeBSD.pm
@@ -1,0 +1,92 @@
+########################################################################
+                    package My::Build::FreeBSD;
+########################################################################
+
+use strict;
+use warnings;
+use parent 'My::Build';
+use File::ShareDir;
+
+# We don't need any extra args for pure Linux builds, but this may be
+# overridden by derived classes
+sub extra_config_args { '' }
+
+sub make_command { 'gmake' }
+
+sub install_to_prefix {
+	my ($self, $prefix) = @_;
+	
+	return if $self->notes('build_state') eq $prefix;
+	
+	$self->my_clean;
+	
+	# Get the system-specific make command
+	my $make = $self->make_command;
+	
+	# move into the source directory and perform configure, make, and install
+	chdir 'src';
+	
+	# clean followed by a normal incantation
+	my $extra_args = $self->extra_config_args;
+	system("./configure --prefix=$prefix $extra_args")
+		and die 'tcc build failed at ./configure';
+	system($make)
+		and die 'tcc build failed at make';
+	system($make, 'install')
+		and die 'tcc build failed at make install';
+	
+	# Move back to the root directory
+	chdir '..';
+	
+	# Record the current build state so we don't build more than necessary.
+	$self->notes('build_state', $prefix);
+}
+
+use Cwd;
+sub ACTION_code {
+	my $self = shift;
+	$self->notes('build_state', '') unless defined $self->notes('build_state');
+	
+	# Build an absolute prefix to our (local) sharedir, build and install
+	my $prefix = File::Spec->catdir(getcwd(), 'share');
+	$self->install_to_prefix($prefix);
+	
+	$self->SUPER::ACTION_code;
+}
+
+sub my_clean {
+	my $self = shift;
+	return unless -f 'src/config.mak';
+	
+	# Get the system-specific make command
+	my $make = $self->make_command;
+	
+	chdir 'src';
+	system($make, 'clean');
+	chdir '..';
+}
+
+use File::Path;
+sub ACTION_install {
+	my $self = shift;
+	
+	# For unixish systems, we must re-build with the new prefix so that all of
+	# the baked-in paths are correct. I just wanna say this:
+	#my $prefix = File::ShareDir::dist_dir('Alien-TinyCC');
+	# Unfortunately, this won't work because File::ShareDir expects the
+	# folder to already exist.
+	
+	# Instead, I copy code from Alien::Base::ModuleBuild to calculate the
+	# sharedir location by-hand:
+	my $prefix = File::Spec->catdir($self->install_destination('lib'),
+		qw(auto share dist Alien-TinyCC));
+	
+	# Completely rebuild (and install) the compiler with the new prefix
+	File::Path::make_path($prefix);
+	$self->install_to_prefix($prefix);
+	
+	# Proceed with the rest of the install
+	$self->SUPER::ACTION_install;
+}
+
+1;


### PR DESCRIPTION
This changes the command "make" for freebsd to be "gmake".

The same problem surely occurred with the other BSDs which are failing tests on cpantesters, so it would be better to make the whole BSD module do this. However there is no BSD module yet. Perhaps this can be sent to cpan testers for the next trial version, and if successful then create the whole BSD module for all the BSDs. I think the use of "gmake" is common to all the systems.

Also "gmake" may not be installed on some FreeBSD systems. It usually will get sucked in via installing a port or something, but it would be sensible to actually test there is a gmake command and print out a message if the gmake cannot be found.
