### PR TITLE
support when cccdlflags uses -fpic (lowercase)

### DIFF
--- a/inc/My/Build/Linux.pm
+++ b/inc/My/Build/Linux.pm
@@ -31,6 +31,8 @@ sub install_to_prefix {
 	$ENV{CFLAGS} = '' unless $ENV{CFLAGS};  # Avoid undef warnings
 	$ENV{CFLAGS} .= ' -fPIC'
 		if $Config{cccdlflags} =~ /-fPIC/ and $ENV{CFLAGS} !~ /-fPIC/;
+	$ENV{CFLAGS} .= ' -fpic'
+		if $Config{cccdlflags} =~ /-fpic/ and $ENV{CFLAGS} !~ /-fpic/;
 	
 	# clean followed by a normal incantation
 	my $extra_args = $self->extra_config_args;


### PR DESCRIPTION
Perl brew on my Debian kFreeBSD box build with -fpic instead of -fPIC.  Not entirely sure why:

```
debiankfreebsd64% perl -MConfig= -E 'say $Config{cccdlflags}'
-fpic
debiankfreebsd64% /usr/bin/perl -MConfig= -E 'say $Config{cccdlflags}'
-fPIC
```

Either way, this patch makes it build a properly relocatable static lib needed for XS / FFI. 
