### PR TITLE
compile and run test programs in separate steps

### DIFF
--- a/inc/My/Build.pm
+++ b/inc/My/Build.pm
@@ -10,6 +10,7 @@ sub ACTION_build {
 	my $self = shift;
 	
 	mkdir 'share';
+	mkdir '.build';
 	
 	$self->SUPER::ACTION_build;
 }

--- a/t/20-tcc-exec.t
+++ b/t/20-tcc-exec.t
@@ -28,7 +28,8 @@ END {
 	unlink 'test.c';
 }
 
-my $results = `tcc -run test.c`;
+`tcc test.c -o .build/test`;
+my $results = `.build/test`;
 is($results, 'Good to go', 'tcc compiled the code correctly')
 	or diag(join("\n", "tcc printed [$results]",
 		"tcc configuration:",

--- a/t/30-tcc-test-suite.t
+++ b/t/30-tcc-test-suite.t
@@ -47,8 +47,12 @@ for my $test_file (@test_files) {
 	my $args = '';
 	$args = '- arg1 arg2 arg3 arg4' if $test_name =~ /args/;
 	
+	# Compile the test
+	(my $test_bin = $test_file) =~ s/src.tests.tests2.//;
+	`tcc $test_file -lm -o .build/$test_bin`;
+
 	# Run the test, clear trailing whitespace
-	my $output = `tcc -run $test_file $args`;
+	my $output = `cd .build && ./$test_bin $args`;
 	$output =~ s/\s+\n/\n/g;
 	
 	# Tweak the output for the args test

--- a/t/30-tcc-test-suite.t
+++ b/t/30-tcc-test-suite.t
@@ -4,6 +4,10 @@ use Test::More;
 
 use Alien::TinyCC;
 
+# Need '.' on PATH so arg 0 matches expectation in args test
+use Env qw( @PATH );
+push @PATH, '.';
+
 # Needed for quick patching
 use inc::My::Build;
 
@@ -52,7 +56,7 @@ for my $test_file (@test_files) {
 	`tcc $test_file -lm -o .build/$test_bin`;
 
 	# Run the test, clear trailing whitespace
-	my $output = `cd .build && ./$test_bin $args`;
+	my $output = `cd .build && $test_bin $args`;
 	$output =~ s/\s+\n/\n/g;
 	
 	# Tweak the output for the args test


### PR DESCRIPTION
When both installing from cpan and when running tests out of the github repo proper I am getting segfaults.  There seems to be either a race condition or other problem with `tcc -run`, as it is segfaulting when trying to invoke the program main.

This PR changes the test logic to split test program compilation and execution into two separate steps.  This seems to avoid the problem.

My environment:
> Fedora 21, x86_64, 12GB RAM
> Perl 5.18.4

```
$ pwd
/home/dylan.cali/git/Alien-TinyCC
$ ulimit -c 99999
$ export CFLAGS=-g3
$ perl Build.PL
...
$ ./Build
...
$ ./Build test
t/10-path-tests.t ...... ok
t/20-tcc-exec.t ........ 1/?
#   Failed test 'tcc compiled the code correctly'
#   at t/20-tcc-exec.t line 32.
#          got: ''
#     expected: 'Good to go'
# tcc printed []
# tcc configuration:
# install: /home/dylan.cali/git/Alien-TinyCC/share/lib/tcc/
# crt:
#   /usr/lib64/
# libraries:
#   /usr/lib64/
#   /usr/lib64
#   /lib64/
#   /lib64
#   /usr/local/lib64/
#   /usr/local/lib64
# include:
#   /usr/local/include/
#   /usr/local/include
#   /usr/include/
#   /usr/include
#   /home/dylan.cali/git/Alien-TinyCC/share/lib/tcc/include
# elfinterp:
#   /lib64/ld-linux-x86-64.so.2
# Looks like you failed 1 test of 1.
t/20-tcc-exec.t ........ Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests
t/30-tcc-test-suite.t .. 1/?
#   Failed test 'tcc test src/tests/tests2/00_assignment.c'
#   at t/30-tcc-test-suite.t line 79.
#          got: ''
#     expected: '42
# 64
# 12, 34'

#   Failed test 'tcc test src/tests/tests2/01_comment.c'
#   at t/30-tcc-test-suite.t line 79.
#          got: ''
#     expected: 'Hello
# Hello
# Hello
# Hello
# Hello'
...
# many more errors with got: '', expected '<something>'

$ ls
blib        core.18468  core.18480  core.18492  core.18504              lib
_build      core.18469  core.18481  core.18493  core.18505              MANIFEST
Build       core.18470  core.18482  core.18494  core.18506              MYMETA.json
Build.PL    core.18471  core.18483  core.18495  core.18507              MYMETA.yml
Changes     core.18472  core.18484  core.18496  core.18508              README.pod
core.18456  core.18473  core.18485  core.18497  core.18509              share
core.18462  core.18474  core.18486  core.18498  core.18510              src
core.18463  core.18475  core.18487  core.18499  core.18511              t
core.18464  core.18476  core.18488  core.18500  core.18512
core.18465  core.18477  core.18489  core.18501  core.18513
core.18466  core.18478  core.18490  core.18502  git-pre-commit-hook.pl
core.18467  core.18479  core.18491  core.18503  inc
```

digging into the core files with gdb you can see the explosion is occuring when trying to invoke the program main.
```
$ gdb ./share/bin/tcc core.18456
(gdb) bt
#0  0x000000000069ea50 in ?? ()
#1  0x0000000000420c21 in tcc_run (s1=0x672010, argc=1, argv=0x7ffc100c9c68) at tccrun.c:123
#2  0x00000000004020e6 in main (argc=3, argv=0x7ffc100c9c58) at tcc.c:332
(gdb) up
123             ret = (*prog_main)(argc, argv)
```

The `?? ()` indicates to me the program main is either not found or not available when `tcc_run` tries to invoke it.  I'm not sure of the cause, but doing compilation and execution in separate steps avoids the problem.
